### PR TITLE
Many small updates, including filter by stream_id.

### DIFF
--- a/tvapi/api/survey/database.py
+++ b/tvapi/api/survey/database.py
@@ -124,6 +124,7 @@ class DatabaseEvent:
             mongo.collection_add_index(index_name='timestamp', ascending=False, unique=False)
             mongo.collection_add_index(index_name='ufm_number', ascending=True, unique=False)
             mongo.collection_add_index(index_name='action_type', ascending=True, unique=False)
+            mongo.collection_add_index(index_name='stream_id', ascending=True, unique=False)
             self.send_status(status_type=status_type, is_complete=True)
 
 

--- a/tvapi/api/survey/find.py
+++ b/tvapi/api/survey/find.py
@@ -67,6 +67,7 @@ class SmurfDataLocation(NamedTuple):
     action_type: str
     path: str
     ufm_label: str
+    stream_id: str
     outputs: Optional[List[str]] = None
     plots: Optional[List[str]] = None
 
@@ -95,9 +96,9 @@ def smurf(timestamp_min: int, timestamp_max: int, smurf_data_path: str, verbose:
             # the data is likely to be outside the data is outside the requested time range
             continue
         full_path_coarse_time_dir = os.path.join(smurf_data_path, str(coarse_time_int))
-        for ufm_dir in get_ufm_dirs(parent_dir=full_path_coarse_time_dir):
-            ufm_letter, ufm_number = parse_ufm_name(ufm_dir)
-            full_path_ufm_dir = os.path.join(full_path_coarse_time_dir, ufm_dir)
+        for stream_id in get_ufm_dirs(parent_dir=full_path_coarse_time_dir):
+            ufm_letter, ufm_number = parse_ufm_name(stream_id)
+            full_path_ufm_dir = os.path.join(full_path_coarse_time_dir, stream_id)
             for action_dir in os.listdir(full_path_ufm_dir):
                 full_path_action_dir = os.path.join(full_path_ufm_dir, action_dir)
                 timestamp_int, action_type = parse_action_name(action_dir)
@@ -129,6 +130,7 @@ def smurf(timestamp_min: int, timestamp_max: int, smurf_data_path: str, verbose:
                     action_type=action_type,
                     path=path_formatted,
                     ufm_label=f"{ufm_letter.upper()}v{ufm_number}",
+                    stream_id=stream_id,
                     outputs=data_files_by_type['outputs'],
                     plots=data_files_by_type['plots'],
                 )

--- a/tvapp/app/[[...query]]/page.tsx
+++ b/tvapp/app/[[...query]]/page.tsx
@@ -6,6 +6,7 @@ import { nowTimestamp } from "@/utils/time/time";
 import { TELEVIEW_VERBOSE } from "@/utils/config";
 import { getCurrentIndexRange, parseFilterURL } from "@/utils/url/filter";
 import getDataMap, { getCursorPerFilter, returnDocumentsSlice } from "@/utils/mongo/request_data";
+import {findAvailableStrings} from "@/utils/text_parse";
 
 
 
@@ -20,15 +21,9 @@ export default async function Page({ params }: { params: { query: Array<string> 
     const valuesMap = await getDataMap()
     // Parse Action-types from the database
     const actionTypes = valuesMap.get("actionTypes")
-    const availableActionTypes = actionTypes.filter((actionType: string) => {
-        const filterValues = filterState['action_type']
-        if (filterValues !== undefined) {
-            return !filterValues.has(actionType)
-        }
-        return true
-    })
+    const availableActionTypes = findAvailableStrings(actionTypes, filterState.action_type)
     // Parse Time data from the database
-    const coarseTimestamps = valuesMap.get("coarseTimestamps")
+    //const coarseTimestamps = valuesMap.get("coarseTimestamps")
     const timestamps = valuesMap.get("timestamps")
     let timestampDatabaseMin: number | undefined = parseInt(timestamps[0])
     if (timestampDatabaseMin === undefined || Number.isNaN(timestampDatabaseMin)) {
@@ -38,6 +33,9 @@ export default async function Page({ params }: { params: { query: Array<string> 
     if (timestampDataBaseMax === undefined || Number.isNaN(timestampDataBaseMax)) {
         timestampDataBaseMax = nowTimestamp()
     }
+    // parse the streamIDs from the database
+    const streamIDs = valuesMap.get("streamIDs")
+    const availableStreamIDs = findAvailableStrings(streamIDs, filterState.stream_id)
     // get the cursor for the current filter state
     const dataCursor = await getCursorPerFilter(filterState)
     // get a slice of the available documents
@@ -50,6 +48,7 @@ export default async function Page({ params }: { params: { query: Array<string> 
             documentItemLimit={TELEVIEW_DEFAULT_ITEMS_PER_PAGE}
             docArray={docArray}
             availableActionTypes={availableActionTypes}
+            availableStreamIDs={availableStreamIDs}
             maxIndex={maxIndex}
             timestampDatabaseMin={timestampDatabaseMin}
             timestampDatabaseMax={timestampDataBaseMax}

--- a/tvapp/app/data_view/[...id]/page.tsx
+++ b/tvapp/app/data_view/[...id]/page.tsx
@@ -21,6 +21,7 @@ export default async function Page({ params }: { params: { id: Array<string> } }
         timestamp: new Set([timestamp]),
         ufm_letter: new Set([ufm_letter]),
         ufm_number: new Set([ufm_number]),
+        stream_id: undefined,
         timestamp_range: undefined,
         timestamp_coarse: undefined,
     }

--- a/tvapp/components/MenuLinks/match_filter.tsx
+++ b/tvapp/components/MenuLinks/match_filter.tsx
@@ -7,6 +7,7 @@ import filterUpdateLink, {ModifierState} from "@/utils/url/filter";
 
 type MatchFilterMenuInput = {
     availableActionTypes:  Array<string>
+    availableStreamIDs: Array<string>,
     modifierState: ModifierState,
     filterState: FilterState
 }
@@ -30,16 +31,28 @@ function matchLinkWrapper(filterLinks: Array<React.ReactElement>): React.ReactEl
 }
 
 
-export default function MatchFilterMenu({availableActionTypes, modifierState, filterState}: MatchFilterMenuInput) : React.ReactElement {
+export default function MatchFilterMenu({
+                                            availableActionTypes,
+                                            availableStreamIDs,
+                                            modifierState,
+                                            filterState
+                                        }: MatchFilterMenuInput) : React.ReactElement {
     const actionTypeFilterLinks = availableActionTypes.map((actionType: string) => {
         return filterUpdateLink(modifierState, filterState, 'action_type', actionType, true)
     })
+    const streamIDFilterLinks = availableStreamIDs.map((streamID: string) => {
+        return filterUpdateLink(modifierState, filterState, 'stream_id', streamID, true)
+    })
     return (
         <div className="flex flex-col">
-            <div className="text-2xl text-tvgrey ">
-                {'action_type'}
+            <div className="text-2xl text-tvgrey">
+                {'Action Type'}
             </div>
             {matchLinkWrapper(actionTypeFilterLinks)}
+            <div className="text-2xl text-tvgrey mt-4">
+                {'Stream ID'}
+            </div>
+            {matchLinkWrapper(streamIDFilterLinks)}
         </div>
     )
 }

--- a/tvapp/components/NavDocs/table.tsx
+++ b/tvapp/components/NavDocs/table.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
 import React, {useContext} from "react";
 
-import {TELEVIEW_VERBOSE} from "@/utils/config";
 import {QueryContext} from "@/states/query";
+import {TELEVIEW_VERBOSE} from "@/utils/config";
+import {timestampToIsoString} from "@/utils/time/time";
 import {FilterState} from "@/utils/mongo/request_data";
 import {ModifierState, genFilterURL, getCurrentIndexRange} from "@/utils/url/filter";
 
@@ -114,11 +115,13 @@ export default function NavTable(): React.ReactElement {
             <div className="flex justify-center text-tvgry border-4 bg-tvbrown border-tvgreen overflow-auto">
                 <div className="table-auto">
                     <div className="table-header-group">
-                        <div className="table-row">
-                            <div className="table-cell px-4 py-2">Timestamp</div>
+                        <div className="table-row text-center">
                             <div className="table-cell px-4 py-2">Action Type</div>
+                            <div className="table-cell px-4 py-2">Date Time (UTC)</div>
+                            <div className="table-cell px-4 py-2">Timestamp</div>
                             <div className="table-cell px-4 py-2">UFM Label</div>
                             <div className="table-cell px-4 py-2">Timestamp Course</div>
+                            <div className="table-cell px-4 py-2">Stream ID</div>
                         </div>
                     </div>
                     <div className="table-row-group">
@@ -130,7 +133,9 @@ export default function NavTable(): React.ReactElement {
                             }
                             const actionType = doc['action_type']
                             const ufmLabel = doc['ufm_label']
+                            const streamId = doc['stream_id']
                             const timestampCoarse = doc['timestamp_coarse']
+                            const [date, time] = timestampToIsoString(timestamp).split('T')
                             const linkString: string = '/data_view/' + ufmLabel + '/' + timestamp.toString() + '/' + actionType
                             return (
                                 <Link
@@ -140,16 +145,22 @@ export default function NavTable(): React.ReactElement {
                                     prefetch={false}
                                 >
                                     <div className="table-cell border px-4 py-2">
-                                        {timestamp}
+                                        {actionType}
                                     </div>
                                     <div className="table-cell border px-4 py-2">
-                                        {actionType}
+                                        {date} {time}
+                                    </div>
+                                    <div className="table-cell border px-4 py-2">
+                                        {timestamp}
                                     </div>
                                     <div className="table-cell border px-4 py-2">
                                         {ufmLabel}
                                     </div>
                                     <div className="table-cell border px-4 py-2">
                                         {timestampCoarse}
+                                    </div>
+                                    <div className="table-cell border px-4 py-2">
+                                        {streamId}
                                     </div>
                                 </Link>
                             )

--- a/tvapp/components/menu/menu_view.tsx
+++ b/tvapp/components/menu/menu_view.tsx
@@ -10,6 +10,7 @@ export default function  MenuViewer (): React.ReactElement {
         modifierState,
         filterState,
         availableActionTypes,
+        availableStreamIDs,
         timestampDatabaseMin,
         timestampDatabaseMax,
         selectedTimestampMin,
@@ -21,16 +22,14 @@ export default function  MenuViewer (): React.ReactElement {
         isMatchMenuOpen,
         isTimeRangeMenuOpen,
         closeAllMenus
-    } = useContext(QueryContext)
-
-
+    } = useContext(QueryContext);
 
     if (isAnyMenuOpen) {
         if (isRemoveFilterMenuOpen) {
             return (
                 <>
                     <ClickBarrier onClick={closeAllMenus}/>
-                    <div className="h-full w-auto absolute top-0 left-0 z-40">
+                    <div className="h-full w-auto absolute top-0 left-0 z-40 overflow-y-auto">
                         <Drawer
                             closeCallback={closeAllMenus}
                             title={"Remove Filters Menu"}>
@@ -43,11 +42,11 @@ export default function  MenuViewer (): React.ReactElement {
             return (
                 <>
                     <ClickBarrier onClick={closeAllMenus}/>
-                    <div className="h-full w-auto absolute top-0 left-0 z-40">
+                    <div className="h-full w-auto absolute top-0 left-0 z-40 overflow-y-auto">
                         <Drawer
                             closeCallback={closeAllMenus}
                             title={"Match Filters Menu"}>
-                            {MatchFilterMenu({availableActionTypes, modifierState, filterState})}
+                            {MatchFilterMenu({availableActionTypes, availableStreamIDs, modifierState, filterState})}
                         </Drawer>
                     </div>
                 </>
@@ -56,7 +55,7 @@ export default function  MenuViewer (): React.ReactElement {
             return (
                 <>
                     <ClickBarrier onClick={closeAllMenus}/>
-                    <div className="h-full w-auto absolute top-0 left-0 z-40">
+                    <div className="h-full w-auto absolute top-0 left-0 z-40  overflow-y-auto">
                         <Drawer
                             closeCallback={closeAllMenus}
                             title={"Time Range Menu"}>

--- a/tvapp/components/query.tsx
+++ b/tvapp/components/query.tsx
@@ -5,10 +5,10 @@ import React, {ReactElement} from "react";
 
 import QueryProvider from "@/states/query";
 import MenuBar from "@/components/menu/menu_bar";
+import {ModifierState} from "@/utils/url/filter";
 import NavTable from "@/components/NavDocs/table";
-import { ModifierState } from "@/utils/url/filter";
 import MenuViewer from "@/components/menu/menu_view";
-import { FilterState } from "@/utils/mongo/request_data";
+import {FilterState} from "@/utils/mongo/request_data";
 
 
 export function QueryClient(): ReactElement {
@@ -36,6 +36,7 @@ type QueryClientInput = {
     documentItemLimit: number
     docArray: Array<mongo.Document>
     availableActionTypes: Array<string>
+    availableStreamIDs: Array<string>
     maxIndex: number
     timestampDatabaseMin: number
     timestampDatabaseMax: number
@@ -43,7 +44,18 @@ type QueryClientInput = {
 
 
 // Here is the entry point to the client side components using the data from the server
-export default function QueryPage({modifierState, filterState, documentItemLimit, docArray, availableActionTypes, maxIndex, timestampDatabaseMin, timestampDatabaseMax} : QueryClientInput): React.ReactElement {
+export default function QueryPage(
+    {
+        modifierState,
+        filterState,
+        documentItemLimit,
+        docArray,
+        availableActionTypes,
+        availableStreamIDs,
+        maxIndex,
+        timestampDatabaseMin,
+        timestampDatabaseMax
+    } : QueryClientInput): React.ReactElement {
     return (
         <QueryProvider
             modifierState={modifierState}
@@ -51,6 +63,7 @@ export default function QueryPage({modifierState, filterState, documentItemLimit
             documentItemLimit={documentItemLimit}
             docArray={docArray}
             availableActionTypes={availableActionTypes}
+            availableStreamIDs={availableStreamIDs}
             maxIndex={maxIndex}
             timestampDatabaseMin={timestampDatabaseMin}
             timestampDatabaseMax={timestampDatabaseMax}

--- a/tvapp/package.json
+++ b/tvapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tvapp",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/tvapp/states/query.tsx
+++ b/tvapp/states/query.tsx
@@ -1,8 +1,9 @@
 import { createContext, Dispatch, ReactNode, SetStateAction, useState } from "react";
 
-import {TELEVIEW_DEFAULT_ITEMS_PER_PAGE, TELEVIEW_VERBOSE} from "@/utils/config";
-import { FilterState } from "@/utils/mongo/request_data";
 import {ModifierState} from "@/utils/url/filter";
+import {streamIDToUfmNumber} from "@/utils/text_parse";
+import {FilterState} from "@/utils/mongo/request_data";
+import {TELEVIEW_DEFAULT_ITEMS_PER_PAGE, TELEVIEW_VERBOSE} from "@/utils/config";
 
 
 interface AppContextInterface {
@@ -11,6 +12,7 @@ interface AppContextInterface {
     documentItemLimit: number,
     docArray: Array<any>,
     availableActionTypes: Array<string>,
+    availableStreamIDs: Array<string>,
     maxIndex: number,
     timestampDatabaseMin: number,
     timestampDatabaseMax: number,
@@ -37,11 +39,13 @@ export const queryContextDefaultValue: AppContextInterface = {
         timestamp_coarse: undefined,
         ufm_letter: undefined,
         ufm_number: undefined,
+        stream_id: undefined,
         timestamp_range: undefined
     },
     documentItemLimit: TELEVIEW_DEFAULT_ITEMS_PER_PAGE,
     docArray: [],
     availableActionTypes: [],
+    availableStreamIDs: [],
     maxIndex: 0,
     timestampDatabaseMin: 0,
     timestampDatabaseMax: 4102444800,
@@ -69,6 +73,7 @@ type QueryProviderInput = {
     documentItemLimit: number
     docArray: Array<any>
     availableActionTypes: Array<string>,
+    availableStreamIDs: Array<string>,
     maxIndex: number
     timestampDatabaseMin: number
     timestampDatabaseMax: number
@@ -81,11 +86,14 @@ export default function QueryProvider(
         documentItemLimit=TELEVIEW_DEFAULT_ITEMS_PER_PAGE,
         docArray = [],
         availableActionTypes = [],
+        availableStreamIDs = [],
         maxIndex = 0,
         timestampDatabaseMin = 0,
         timestampDatabaseMax = 0,
         children
     } : QueryProviderInput) {
+    // sort the stream IDs so that they are in numerical order
+    availableStreamIDs.sort((a, b) => streamIDToUfmNumber(a) - streamIDToUfmNumber(b));
     /* changes in these states will trigger a re-render of components that use them */
     // timestamp range states
     const [selectedTimestampMin, setSelectedTimestampMin] = useState<number>(timestampDatabaseMin);
@@ -116,6 +124,7 @@ export default function QueryProvider(
             documentItemLimit,
             docArray,
             availableActionTypes,
+            availableStreamIDs,
             maxIndex,
             timestampDatabaseMin,
             timestampDatabaseMax,

--- a/tvapp/utils/config.tsx
+++ b/tvapp/utils/config.tsx
@@ -8,7 +8,7 @@ const TELEVIEW_VERBOSE_RAW = process.env['TELEVIEW_VERBOSE']
 
 export let TELEVIEW_VERBOSE: boolean
 if (TELEVIEW_VERBOSE_RAW === undefined) {
-    TELEVIEW_VERBOSE = true
+    TELEVIEW_VERBOSE = false
 } else {
     TELEVIEW_VERBOSE = TELEVIEW_VERBOSE_RAW !== "0"
 }
@@ -39,7 +39,6 @@ if (TELEVIEW_DEFAULT_ITEMS_PER_PAGE_RAW === undefined) {
         TELEVIEW_DEFAULT_ITEMS_PER_PAGE = 100
     }
 }
-export const documentLimitDefault = TELEVIEW_DEFAULT_ITEMS_PER_PAGE
 export const minIsoDate = "1970-01-01T00:00:00"
 export const maxIsoDate = "2100-01-01T00:00:00"
 

--- a/tvapp/utils/mongo/client.tsx
+++ b/tvapp/utils/mongo/client.tsx
@@ -1,4 +1,4 @@
-const {MongoClient} = require('mongodb');
+import {MongoClient} from 'mongodb';
 import * as mongoDB from "mongodb";
 import { mongoURI } from "@/utils/config";
 

--- a/tvapp/utils/text_parse.tsx
+++ b/tvapp/utils/text_parse.tsx
@@ -1,0 +1,22 @@
+import {FilterState} from "@/utils/mongo/request_data";
+
+export function streamIDToUfmNumber(stream_id: string): number {
+    const aArray = stream_id.split('v')
+    // get the last element of the array
+    const aNumberString = aArray.pop()
+    let aNumber = -1
+    if (aNumberString) {
+        aNumber = parseInt(aNumberString)
+    }
+    return aNumber
+}
+
+
+export function findAvailableStrings(allStringValues: Array<string>, filteredStringValues: Set<string> | undefined): Array<string> {
+    return allStringValues.filter((actionType: string) => {
+        if (filteredStringValues !== undefined) {
+            return !filteredStringValues.has(actionType)
+        }
+        return true
+    })
+}

--- a/tvapp/utils/url/filter.tsx
+++ b/tvapp/utils/url/filter.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import Link from 'next/link';
 
-import { TELEVIEW_DEFAULT_ITEMS_PER_PAGE } from "@/utils/config";
-import { FilterState } from "@/utils/mongo/request_data";
-import { simplifyRanges, timestampToIsoString } from "@/utils/time/time";
+import {FilterState} from "@/utils/mongo/request_data";
+import {TELEVIEW_DEFAULT_ITEMS_PER_PAGE} from "@/utils/config";
+import {simplifyRanges, timestampToIsoString} from "@/utils/time/time";
 
 
 const rangeModifierDataTypes = new Set(['document_range'])
@@ -140,6 +140,7 @@ export function parseFilterURL(filterURL: Array<string> | undefined, verbose: bo
         timestamp_coarse: undefined,
         ufm_letter: undefined,
         ufm_number: undefined,
+        stream_id: undefined,
         timestamp_range: undefined,
     }
     if (paramsStrings.length > 1) {
@@ -161,6 +162,9 @@ export function parseFilterURL(filterURL: Array<string> | undefined, verbose: bo
                     break;
                 case "ufm_number":
                     filterState.ufm_number = parseSingleModifierNumber(modifierValuesString)
+                    break;
+                case "stream_id":
+                    filterState.stream_id = parseSingleModifierString(modifierValuesString)
                     break;
                 case "timestamp_range":
                     filterState.timestamp_range = simplifyRanges(parseModifierRanges(modifierValuesString))
@@ -247,6 +251,9 @@ function encodeToURLFilter(filterState: FilterState, primaryOperator: string = "
                 break;
             case "ufm_number":
                 stateURL += encodeToURFilterKeyValue(key, filterState.ufm_number, primaryOperator, secondaryOperator)
+                break;
+            case "stream_id":
+                stateURL += encodeToURFilterKeyValue(key, filterState.stream_id, primaryOperator, secondaryOperator)
                 break;
             case "timestamp_range":
                 let simplifiedTimeStampRange: Array<[number, number]> | undefined = undefined
@@ -358,6 +365,9 @@ function addSubtractFilter(filterState: FilterState, filterKey: string, filterVa
             break;
         case "ufm_number":
             if (typeof filterValue === "number") newFilterState.ufm_number = addSubtractFilterNumber(filterValue, filterState.ufm_number, add)
+            break;
+        case "stream_id":
+            if (typeof filterValue === "string") newFilterState.stream_id = addSubtractFilterString(filterValue, filterState.stream_id, add)
             break;
         case "timestamp_range":
             if (typeof filterValue === "object") newFilterState.timestamp_range = addSubtractFilterRange(filterValue, filterState.timestamp_range, add)
@@ -491,6 +501,12 @@ export function filterIteratorMap(filterState: FilterState): FilterIteratorMapIn
             case "ufm_letter":
                 if (filterState.ufm_letter !== undefined) {
                     filterValues = Array.from(filterState.ufm_letter)
+                }
+                break
+            case "stream_id":
+                if (filterState.stream_id !== undefined) {
+                    filterValues = Array.from(filterState.stream_id)
+                    console.log("FilterIteratorMap: stream_id: ", filterValues)
                 }
                 break
             case "timestamp_range":


### PR DESCRIPTION
StreamID, an extremely repetitive component for the smurf data directory structure, is not natively supported for database indexing and filter functions. Stream ID is formatted as ufm_{a_letter}v{a_number} where a_number is the only unique piece of information.

Stream ID was added as a data column; however, it was hard enough to read that I left the complimentary UFM Label in place.

Stream ID was added as an option to for matching filters, allowing users to select only the UFMs of interest. Since Stream ID is an indexed values in the database, I don't expect any performance degridation compared to simply filter by the UFM number, the only unique information in the Stream ID.

The table is now sorted in reverse chronological order by default. This means that the newest data will always be at the top for any given filter state. Anticipating users can simply refresh the page at any filter state to get the latest values for a given filter state.

A human-readable DataTime, generated from the timestamp value, was added to as a column in table.tsx.

Incremented to version 0.1.7