### PR TITLE
Bug fix for light-mode.

### DIFF
--- a/tvapp/package.json
+++ b/tvapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tvapp",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/tvapp/styles/globals.css
+++ b/tvapp/styles/globals.css
@@ -3,17 +3,9 @@
 @tailwind utilities;
 
 :root {
-    --foreground-rgb: 0, 0, 0;
-    --background-start-rgb: 214, 219, 220;
-    --background-end-rgb: 255, 255, 255;
-}
-
-@media (prefers-color-scheme: dark) {
-    :root {
-        --foreground-rgb: 255, 255, 255;
-        --background-start-rgb: 0, 0, 0;
-        --background-end-rgb: 0, 0, 0;
-    }
+    --foreground-rgb: 255, 255, 255;
+    --background-start-rgb: 0, 0, 0;
+    --background-end-rgb: 0, 0, 0;
 }
 
 body {


### PR DESCRIPTION
Fixes GitHub Issue #19
Bug fix where styling was considering was doing a media query making different default settings for light-mode and dark-mode. Only dark-mode looked right, now the dark-mode settings are the overall defaults, media queries have been removed. Two modes are too much to manage in the TeleView project.

Incrementing to version 0.2.2